### PR TITLE
Fix color parser hex pattern

### DIFF
--- a/src/BBCodeParser.php
+++ b/src/BBCodeParser.php
@@ -34,7 +34,7 @@ class BBCodeParser
             'content' => '$2'
         ],
         'color' => [
-            'pattern' => '/\[color\=(#[A-f0-9]{6}|#[A-f0-9]{3})\](.*?)\[\/color\]/s',
+            'pattern' => '/\[color\=(#[A-Fa-f0-9]{6}|#[A-Fa-f0-9]{3})\](.*?)\[\/color\]/s',
             'replace' => '<font color="$1">$2</font>',
             'content' => '$2'
         ],


### PR DESCRIPTION
## Summary
- fix color regex to correctly accept uppercase hex values

## Testing
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684154fa38fc832db322569b56eece17