### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ All Notable changes to `weiloon1234\BBCodeParser` will be documented in this fil
 ## v1.3.0 - 2014-06-30
 
 ### Fixed
-- The only/except functionally have been broken since like 1.1, but now it´s working. Better late then never!
+- The only/except functionally have been broken since like 1.1, but now it´s working. Better late than never!
 
 ## v1.2.7 - 2014-05-19
 


### PR DESCRIPTION
## Summary
- correct a small typo in the v1.3.0 entry of CHANGELOG.md

## Testing
- `composer -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684154fcc028832dbcd4b74044012fe1